### PR TITLE
Opt/support oss endpoint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import xerial.sbt.Sonatype._
 
 organization := "io.iftech"
 organizationName := "IFTech"
-version := "1.0.3-SNAPSHOT"
+version := "1.0.3.1-SNAPSHOT"
 description := "S3 Plugin for sbt."
 startYear := Some(2019)
 
@@ -12,7 +12,7 @@ lazy val root = (project in file("."))
     sbtPlugin := true,
     name := "sbt-s3",
     libraryDependencies ++= Seq(
-      "com.amazonaws" % "aws-java-sdk-s3" % "1.11.507",
+      "com.amazonaws" % "aws-java-sdk-s3" % "1.11.892",
       "commons-lang" % "commons-lang" % "2.6",
       "javax.xml.bind" % "jaxb-api" % "2.2.11",
       "com.sun.xml.bind" % "jaxb-core" % "2.2.11",

--- a/src/main/scala/io/iftech/S3Keys.scala
+++ b/src/main/scala/io/iftech/S3Keys.scala
@@ -20,6 +20,7 @@ trait S3Keys {
    * Returns: the sequence of uploaded keys (pathnames).
    */
   val s3Upload = TaskKey[Seq[String]]("s3-upload", "Uploads files to an S3 bucket.")
+  val ossUpload = TaskKey[Seq[String]]("oss-upload", "Uploads files to an OSS bucket.")
 
   /**
    * The task "s3-download" downloads a set of files from a specificed S3 bucket.

--- a/src/main/scala/io/iftech/S3Plugin.scala
+++ b/src/main/scala/io/iftech/S3Plugin.scala
@@ -223,6 +223,7 @@ object S3Plugin extends AutoPlugin {
     s3Metadata := Map(),
     mappings in s3Download := Seq(),
     mappings in s3Upload := Seq(),
+    mappings in ossUpload := Seq(),
     s3Progress := false,
     s3ExpirationDate := new java.util.Date(),
     dummy := ()

--- a/src/main/scala/io/iftech/S3Plugin.scala
+++ b/src/main/scala/io/iftech/S3Plugin.scala
@@ -84,7 +84,7 @@ object S3Plugin extends AutoPlugin {
       .withClientConfiguration(makeProxyableClientConfiguration())
       .withCredentials(new AWSStaticCredentialsProvider(credentials))
       .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(System.getenv("AWS_ENDPOINT"), region))
-      .withRegion(region)
+      .withPathStyleAccessEnabled(false)
       .build()
   }
 

--- a/src/main/scala/io/iftech/S3Plugin.scala
+++ b/src/main/scala/io/iftech/S3Plugin.scala
@@ -1,6 +1,7 @@
 package io.iftech
 
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.event.{ProgressEvent, ProgressEventType, SyncProgressListener}
 import com.amazonaws.services.s3.model.{GeneratePresignedUrlRequest, GetObjectRequest, PutObjectRequest}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
@@ -82,6 +83,7 @@ object S3Plugin extends AutoPlugin {
       .standard()
       .withClientConfiguration(makeProxyableClientConfiguration())
       .withCredentials(new AWSStaticCredentialsProvider(credentials))
+      .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(System.getenv("AWS_ENDPOINT"), region))
       .withRegion(region)
       .build()
   }


### PR DESCRIPTION
- [x] Opt：增加 ossUpload 便于区分 Aws 和 Oss 的上传
- [x] Opt：在  AmazonS3ClientBuilder 支持指定 AWS_ENDPOINT 的环境变量